### PR TITLE
textsテーブルのuser_idの外部参照を削除

### DIFF
--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -39,6 +39,4 @@ class Text < ApplicationRecord
         path.fullpath.include?('desc')
     end
 
-    belongs_to :user
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,5 +4,4 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  has_many :texts
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_11_122831) do
+ActiveRecord::Schema.define(version: 2019_06_18_093144) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string "namespace"
@@ -44,8 +44,6 @@ ActiveRecord::Schema.define(version: 2019_06_11_122831) do
     t.string "genre"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "user_id"
-    t.index ["user_id"], name: "index_texts_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
- 勘違いでつけたTextsテーブルのuser_idを削除しました。
  - user_idを外すmigrationファイルを追加。
- Textモデル、Userモデルのhas_manyとbelongs_toも削除。